### PR TITLE
Add rotating cube with arrow controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,42 +8,28 @@
  body{font-family:'Montserrat',sans-serif;max-width:960px;margin:0 auto;padding:24px;line-height:1.5;}
  summary{cursor:pointer;font-size:1.1rem;margin:0.5em 0;}
  details details{margin-left:1em;}
- h1{font-size:2rem;margin-top:0;}
- .avatar{display:block;margin:0 auto 1em;width:50%;max-width:200px;border-radius:50%;height:auto;}
+ h1{font-size:2rem;margin-top:0;text-align:center;}
  .tagline{font-style:italic;color:#555;margin-top:-0.5em;}
  ul li{transition:background-color 0.3s,transform 0.3s;}
  ul li:hover{background-color:#f0f0f0;transform:scale(1.02);}
  a{transition:color 0.3s,transform 0.3s;}
  a:hover{color:#ff6600;transform:scale(1.05);}
 
- #cube-container{perspective:800px;text-align:center;margin:20px auto;width:220px;position:relative;}
- .cube{position:relative;width:200px;height:200px;transform-style:preserve-3d;transition:transform 0.6s;margin:0 auto;}
- .face{position:absolute;width:200px;height:200px;backface-visibility:hidden;}
- .face img{width:100%;height:100%;object-fit:cover;}
- .front{transform:translateZ(100px);}
- .back{transform:rotateY(180deg) translateZ(100px);}
- .right{transform:rotateY(90deg) translateZ(100px);}
- .left{transform:rotateY(-90deg) translateZ(100px);}
- .top{transform:rotateX(90deg) translateZ(100px);}
- .bottom{transform:rotateX(-90deg) translateZ(100px);}
- #controls{display:grid;grid-template-columns:40px 40px 40px;grid-template-rows:40px 40px 40px;grid-template-areas:". up ." "left home right" ". down .";gap:5px;margin-bottom:10px;justify-content:center;margin-left:auto;margin-right:auto;}
- #controls button{width:40px;height:40px;cursor:pointer;}
- #controls .up{grid-area:up;}
- #controls .down{grid-area:down;}
- #controls .left{grid-area:left;}
- #controls .right{grid-area:right;}
- #controls .home{grid-area:home;}
+#cube-container{perspective:800px;margin:20px auto;width:220px;position:relative;}
+.cube{position:relative;width:200px;height:200px;transform-style:preserve-3d;transition:transform 0.6s;margin:0 auto;transform:rotateX(-25deg) rotateY(30deg);animation:wobble 3s infinite alternate;}
+.face{position:absolute;width:200px;height:200px;backface-visibility:hidden;}
+.face img{width:100%;height:100%;object-fit:cover;}
+.control{position:absolute;width:0;height:0;border-style:solid;background:transparent;cursor:pointer;padding:0;}
+.control.up{border-left:15px solid transparent;border-right:15px solid transparent;border-bottom:20px solid #333;top:-30px;left:50%;transform:translateX(-50%);}
+.control.down{border-left:15px solid transparent;border-right:15px solid transparent;border-top:20px solid #333;bottom:-30px;left:50%;transform:translateX(-50%);}
+.control.left{border-top:15px solid transparent;border-bottom:15px solid transparent;border-right:20px solid #333;left:-30px;top:50%;transform:translateY(-50%);}
+.control.right{border-top:15px solid transparent;border-bottom:15px solid transparent;border-left:20px solid #333;right:-30px;top:50%;transform:translateY(-50%);}
+@keyframes wobble{from{transform:rotateX(-25deg) rotateY(30deg);}to{transform:rotateX(-25deg) rotateY(35deg);}}
 </style>
 </head>
 <body>
+<h1>Владимир Ганьшин (34&nbsp;года, Москва)</h1>
 <div id="cube-container">
-  <div id="controls">
-    <button class="up">&#8593;</button>
-    <button class="left">&#8592;</button>
-    <button class="home">&#8635;</button>
-    <button class="right">&#8594;</button>
-    <button class="down">&#8595;</button>
-  </div>
   <div class="cube">
     <div class="face front"><img src="Avatar_Ganshin.jpg" alt="Front"></div>
     <div class="face back"><img src="https://images.unsplash.com/photo-1606851092212-6fb5d3642a5b?auto=format&w=512&h=512&q=80" alt="Back"></div>
@@ -52,10 +38,11 @@
     <div class="face top"><img src="https://images.unsplash.com/photo-1472214103451-9374bd1c798e?auto=format&w=512&h=512&q=80" alt="Top"></div>
     <div class="face bottom"><img src="https://images.unsplash.com/photo-1503341455253-b2e723bb3dbb?auto=format&w=512&h=512&q=80" alt="Bottom"></div>
   </div>
+  <button class="control up" aria-label="Вверх"></button>
+  <button class="control right" aria-label="Вправо"></button>
+  <button class="control down" aria-label="Вниз"></button>
+  <button class="control left" aria-label="Влево"></button>
 </div>
-
-<h1>Владимир Ганьшин</h1>
-<img src="Avatar_Ganshin.jpg" alt="Владимир Ганьшин" class="avatar">
 <p class="tagline">Делаю будущее осязаемым: от 3D‑идеи до работающего прототипа</p>
 <details open><summary><strong>Контакты</strong></summary>
 
@@ -211,12 +198,12 @@
 
 <script>
 const cube=document.querySelector('.cube');
-let rotX=0,rotY=0;
-document.querySelector('#controls .up').addEventListener('click',()=>{rotX+=90;update();});
-document.querySelector('#controls .down').addEventListener('click',()=>{rotX-=90;update();});
-document.querySelector('#controls .left').addEventListener('click',()=>{rotY-=90;update();});
-document.querySelector('#controls .right').addEventListener('click',()=>{rotY+=90;update();});
-document.querySelector('#controls .home').addEventListener('click',()=>{rotX=0;rotY=0;update();});
+let rotX=-25,rotY=30;
+document.querySelector('.control.up').addEventListener('click',()=>{rotX+=90;stopAnim();update();});
+document.querySelector('.control.down').addEventListener('click',()=>{rotX-=90;stopAnim();update();});
+document.querySelector('.control.left').addEventListener('click',()=>{rotY-=90;stopAnim();update();});
+document.querySelector('.control.right').addEventListener('click',()=>{rotY+=90;stopAnim();update();});
+function stopAnim(){cube.style.animation='none';}
 function update(){cube.style.transform=`rotateX(${rotX}deg) rotateY(${rotY}deg)`;}
 </script>
 


### PR DESCRIPTION
## Summary
- replace avatar photo with animated cube
- add triangular arrow buttons around cube
- reposition cube below the heading with age and city
- start cube at an angle and stop animation on user interaction

## Testing
- `npm --version`

------
https://chatgpt.com/codex/tasks/task_e_68477d0d186c83338d2f4576b6f54de4