### PR TITLE
Add meta description to head

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,6 +10,7 @@
   <meta property="og:description" content="Москва, 34 года, эксперт в области промышленного дизайна и инжиниринга" />
   <meta property="og:type" content="profile" />
   <meta property="og:locale" content="ru_RU" />
+  <meta name="description" content="Краткое описание визитки" />
 
   <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@300;400;600&display=swap" rel="stylesheet" />
 


### PR DESCRIPTION
## Summary
- add a short meta description to index.html for SEO

## Testing
- `tidy -errors index.html` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847b39152208333a9ce6e5fdf51ea69