### PR TITLE
Add intro text and reveal button

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,7 +19,13 @@
 <body itemscope itemtype="https://schema.org/Person">
 <header>
   <h1 itemprop="name">Владимир Ганьшин</h1>
-  <img loading="lazy" id="avatar" src="Avatar_Ganshin.jpg" alt="Аватар преподавателя Владимира Ганьшина" itemprop="image" style="max-width:200px;border-radius:0;cursor:pointer;" />
+  <div class="intro-wrapper">
+    <img loading="lazy" id="avatar" src="Avatar_Ganshin.jpg" alt="Аватар преподавателя Владимира Ганьшина" itemprop="image" style="max-width:200px;border-radius:0;cursor:pointer;" />
+    <div class="intro-text">
+      <p>С 2019 года возглавляю технопарк Российского государственного социального университета (РГСУ) и преподаю инженерные дисциплины, в частности, по технологиям аддитивного производства и реверсивного инжиниринга...</p>
+      <button id="showAbout">Подробнее</button>
+    </div>
+  </div>
   <p class="tagline" itemprop="description">Москва, 34 года, эксперт в области промышленного дизайна и инжиниринга</p>
 
   <!-- 5. навигация-якоря -->

--- a/script.js
+++ b/script.js
@@ -23,3 +23,15 @@ overlay.addEventListener('click', () => {
     overlay.style.display = 'none';
   }
 });
+
+// кнопка "Подробнее" раскрывает раздел "Кратко обо мне"
+const showAboutBtn = document.getElementById('showAbout');
+if (showAboutBtn) {
+  showAboutBtn.addEventListener('click', () => {
+    const aboutSection = document.getElementById('about');
+    if (aboutSection) {
+      aboutSection.open = true;
+      aboutSection.scrollIntoView({ behavior: 'smooth' });
+    }
+  });
+}

--- a/style.css
+++ b/style.css
@@ -42,6 +42,27 @@ h1 {
   margin-bottom: 1.2em;
 }
 
+/* ===== intro section ===== */
+.intro-wrapper {
+  display: flex;
+  align-items: flex-start;
+  gap: 1rem;
+  margin-bottom: 1em;
+}
+
+.intro-text p {
+  margin-bottom: 0.5em;
+}
+
+#showAbout {
+  padding: 0.4em 0.8em;
+  font-size: 0.9rem;
+  cursor: pointer;
+  background: var(--gray-050);
+  border: none;
+  border-radius: 4px;
+}
+
 /* ===== мини-навигация ===== */
 .top-nav {
   display: flex;


### PR DESCRIPTION
## Summary
- show profile intro text next to avatar
- style intro section and "Подробнее" button
- make button open the collapsed "Кратко обо мне" section

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6847b976dbd48333a1e0978ec2186b56