### PR TITLE
Add simple carousel to Expert section

### DIFF
--- a/index.html
+++ b/index.html
@@ -191,7 +191,11 @@
   <!-- ===== Экспертная деятельность ===== -->
   <details id="expert">
     <summary><strong>Экспертная деятельность</strong></summary>
-    <img loading="lazy" src="ChatGPT Image 14 апр. 2025 г., 19_42_47.png" alt="Пример экспертной деятельности Владимира Ганьшина" style="max-width:200px;" />
+    <div class="carousel" id="expertCarousel">
+      <button class="prev" id="expertPrev" aria-label="Предыдущее фото">&#10094;</button>
+      <img loading="lazy" id="expertImg" src="" alt="Экспертное фото" />
+      <button class="next" id="expertNext" aria-label="Следующее фото">&#10095;</button>
+    </div>
     <ul>
       <li>«Реверсивный инжиниринг Junior» — Москва 2018</li>
       <li>«Прототипирование» — финал России 2019</li>

--- a/script.js
+++ b/script.js
@@ -23,3 +23,38 @@ overlay.addEventListener('click', () => {
     overlay.style.display = 'none';
   }
 });
+
+// ===== Карусель с фотографиями экспертиз =====
+const expertPhotos = [
+  'https://source.unsplash.com/random/400x250?sig=1',
+  'https://source.unsplash.com/random/400x250?sig=2',
+  'https://source.unsplash.com/random/400x250?sig=3',
+  'https://source.unsplash.com/random/400x250?sig=4',
+  'https://source.unsplash.com/random/400x250?sig=5',
+  'https://source.unsplash.com/random/400x250?sig=6',
+  'https://source.unsplash.com/random/400x250?sig=7',
+  'https://source.unsplash.com/random/400x250?sig=8',
+  'https://source.unsplash.com/random/400x250?sig=9',
+  'https://source.unsplash.com/random/400x250?sig=10'
+];
+
+let expertIndex = 0;
+const expertImg = document.getElementById('expertImg');
+const nextBtn = document.getElementById('expertNext');
+const prevBtn = document.getElementById('expertPrev');
+
+function updateExpert() {
+  expertImg.src = expertPhotos[expertIndex];
+}
+
+if (expertImg) {
+  updateExpert();
+  nextBtn.addEventListener('click', () => {
+    expertIndex = (expertIndex + 1) % expertPhotos.length;
+    updateExpert();
+  });
+  prevBtn.addEventListener('click', () => {
+    expertIndex = (expertIndex - 1 + expertPhotos.length) % expertPhotos.length;
+    updateExpert();
+  });
+}

--- a/style.css
+++ b/style.css
@@ -215,6 +215,38 @@ thead th {
   max-height: 90%;
 }
 
+/* ===== простой карусель ===== */
+.carousel {
+  position: relative;
+  width: 200px;
+  margin: 0.5em 0;
+}
+
+.carousel img {
+  width: 100%;
+  height: auto;
+  border-radius: 4px;
+}
+
+.carousel button {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  background: rgba(0, 0, 0, 0.5);
+  color: #fff;
+  border: none;
+  padding: 0.25em 0.5em;
+  cursor: pointer;
+}
+
+.carousel button.prev {
+  left: 0;
+}
+
+.carousel button.next {
+  right: 0;
+}
+
 .lectures-grid {
   display: grid;
   grid-template-columns: repeat(2, 1fr);


### PR DESCRIPTION
## Summary
- replace Expert section image with a 10-photo carousel
- add minimal carousel styling
- implement carousel logic in JavaScript

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6847bb791d6c8333bf6298b746f9b45a