### PR TITLE
Improve semantic HTML and CSS cleanup

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
   <meta property="og:type" content="profile" />
   <meta property="og:locale" content="ru_RU" />
   <meta property="og:image" content="Avatar_Ganshin.jpg" />
-  <meta name="description" content="Краткое описание визитки" />
+  <meta name="description" content="Короткая визитка Владимира Ганьшина с контактами и опытом" />
 
   <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@300;400;600&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="style.css" />
@@ -20,7 +20,7 @@
 <body itemscope itemtype="https://schema.org/Person">
 <header>
   <h1 itemprop="name">Владимир Ганьшин</h1>
-  <img loading="lazy" id="avatar" src="Avatar_Ganshin.jpg" alt="Аватар преподавателя Владимира Ганьшина" itemprop="image" style="max-width:200px;border-radius:0;cursor:pointer;" />
+  <img loading="lazy" id="avatar" src="Avatar_Ganshin.jpg" alt="Аватар преподавателя Владимира Ганьшина" itemprop="image" />
   <p class="tagline" itemprop="description">Москва, 34 года, эксперт в области промышленного дизайна и инжиниринга</p>
 
   <!-- 5. навигация-якоря -->
@@ -38,17 +38,18 @@
     <a href="#interests">Интересы</a>
   </nav>
 </header>
+<main>
   <div id="storyOverlay" aria-hidden="true">
     <button id="closeOverlay" class="overlay-close">Закрыть</button>
     <img loading="lazy" id="storyImg" src="" alt="Фото из сториз Владимира Ганьшина" />
   </div>
 
   <!-- ===== Контакты ===== -->
-  <details id="contacts" open itemprop="address" itemscope itemtype="https://schema.org/PostalAddress">
-    <summary><strong>Контакты</strong></summary>
-      <address>
-    <ul>
-      <li itemprop="addressLocality">Москва, Россия</li>
+  <section id="contacts" itemprop="address" itemscope itemtype="https://schema.org/PostalAddress">
+    <h2>Контакты</h2>
+    <address>
+      <ul>
+        <li itemprop="addressLocality">Москва, Россия</li>
       <li>
         <svg class="icon" viewBox="0 0 24 24" aria-hidden="true"><path d="M20 4H4a2 2 0 00-2 2v12a2 2 0 002 2h16a2 2 0 002-2V6a2 2 0 00-2-2zm0 2l-8 5-8-5h16zm0 12H4V8l8 5 8-5v10z"/></svg>
         <a href="mailto:ganjshin.vk@example.com" itemprop="email">ganjshin.vk@example.com</a>
@@ -63,48 +64,49 @@
         <a href="https://linkedin.com/in/ganjshin" itemprop="sameAs">linkedin.com/in/ganjshin</a>
       </li>
     </ul>
-      </address>
-  </details>
+    </address>
+  </section>
 
   <!-- ===== Обо мне ===== -->
-  <details id="about">
-    <summary><strong>Кратко обо мне</strong></summary>
+  <section id="about">
+    <h2>Кратко обо мне</h2>
     <video class="about-video" src="output_compressed.mp4" controls aria-label="Краткое видео обо мне">
       <track kind="captions" src="about_captions.vtt" srclang="ru" label="Русские субтитры" default>
     </video>
     <p>С 2019 года возглавляю технопарк Российского государственного социального университета (РГСУ) и преподаю инженерные дисциплины в филиале РГСУ в Пятигорске.</p>
-    <h4>Ключевые факты</h4>
+    <h3>Ключевые факты</h3>
     <ul>
       <li><strong>25+</strong> прикладных инженерных проектов ежегодно</li>
       <li><strong>300+</strong> обученных студентов и специалистов</li>
       <li><strong>10</strong> медалей на национальных и международных чемпионатах</li>
       <li><strong>1 200+</strong> академических часов авторских курсов</li>
     </ul>
-  </details>
+  </section>
 
   <!-- ===== Должности ===== -->
-  <details id="positions">
-    <summary><strong>Текущие должности</strong></summary>
+  <section id="positions">
+    <h2>Текущие должности</h2>
     <table>
+      <caption>Опыт преподавания</caption>
       <thead><tr><th>Годы</th><th>Должность</th><th>Организация</th></tr></thead>
       <tbody>
         <tr><td>2019 – н.в.</td><td itemprop="jobTitle">Руководитель технопарка</td><td>РГСУ, Москва</td></tr>
         <tr><td>2019 – н.в.</td><td itemprop="jobTitle">Преподаватель</td><td>РГСУ, филиал г. Пятигорск</td></tr>
       </tbody>
     </table>
-  </details>
+    </section>
 
   <!-- ===== Навыки ===== -->
-  <details id="skills">
-    <summary><strong>Компетенции и инструменты</strong></summary>
-    <h4>Ключевые навыки</h4>
+  <section id="skills">
+    <h2>Компетенции и инструменты</h2>
+    <h3>Ключевые навыки</h3>
     <ul>
       <li>CAD/CAM/CAE‑моделирование</li>
       <li>Реверсивный инжиниринг</li>
       <li>Аддитивное производство (FDM, DLP, SLA)</li>
       <li>Промышленный дизайн и прототипирование</li>
     </ul>
-    <h4>Технологический стек</h4>
+    <h3>Технологический стек</h3>
     <p><strong>CAD:</strong></p>
     <ul class="tech-list">
       <li><img loading="lazy" class="icon" src="https://raw.githubusercontent.com/simple-icons/simple-icons/master/icons/autodesk.svg" alt="Логотип Inventor Professional" /> Inventor Professional</li>
@@ -130,12 +132,13 @@
       <li><img loading="lazy" class="icon" src="https://raw.githubusercontent.com/simple-icons/simple-icons/master/icons/cplusplus.svg" alt="Логотип C++" /> C++</li>
       <li><img loading="lazy" class="icon" src="https://raw.githubusercontent.com/simple-icons/simple-icons/master/icons/python.svg" alt="Логотип Python" /> Python</li>
     </ul>
-  </details>
+  </section>
 
   <!-- ===== Образование ===== -->
-  <details id="education">
-    <summary><strong>Образование</strong></summary>
+  <section id="education">
+    <h2>Образование</h2>
     <table>
+      <caption>Образование</caption>
       <thead><tr><th>Годы</th><th>Учебное заведение</th><th>Квалификация</th></tr></thead>
       <tbody>
         <tr><td>2008‑2012</td><td itemprop="alumniOf">МГТУ «Станкин», каф. ИТиТФ</td><td>Бакалавр «Технология, оборудование и автоматизация машиностроительных производств»</td></tr>
@@ -143,16 +146,16 @@
         <tr><td>2014‑2018</td><td>МГТУ «Станкин»</td><td>Аспирантура, спец. 05.02.07 «Технология и оборудование механической и физико‑технической обработки»</td></tr>
       </tbody>
     </table>
-    <h4>Повышение квалификации</h4>
+    <h3>Повышение квалификации</h3>
     <ul>
       <li>Инженерный дизайн CAD — Московский Политех</li>
       <li>Государственное и муниципальное управление — РГСУ</li>
     </ul>
-  </details>
+  </section>
 
   <!-- ===== Педагогический опыт ===== -->
-  <details id="experience">
-    <summary><strong>Педагогический опыт</strong></summary>
+  <section id="experience">
+    <h2>Педагогический опыт</h2>
     <table>
       <thead><tr><th>Период</th><th>Организация</th><th>Роль</th></tr></thead>
       <tbody>
@@ -161,7 +164,7 @@
         <tr><td>2021‑2022</td><td>Школа «Марьина Роща им. В. Ф. Орлова»</td><td>Преподаватель ДО (IT‑классы)</td></tr>
       </tbody>
     </table>
-    <h4>Преподаваемые курсы</h4>
+    <h3>Преподаваемые курсы</h3>
     <ul>
       <li><strong>Промышленный дизайн и инжиниринг</strong> (автор)</li>
       <li><strong>Инженерный дизайн (САПР)</strong> (автор)</li>
@@ -169,12 +172,12 @@
       <li><strong>AI‑технологии в профессиональной деятельности</strong> (автор)</li>
       <li><strong>Концепция современного естествознания</strong> (соавтор)</li>
     </ul>
-  </details>
+  </section>
 
   <!-- ===== Награды и достижения ===== -->
-  <details id="awards">
-    <summary><strong>Достижения и награды</strong></summary>
-    <h4>Тренерские успехи</h4>
+  <section id="awards">
+    <h2>Достижения и награды</h2>
+    <h3>Тренерские успехи</h3>
     <ul>
       <li>Тренер сборной России (2019‑2021)
         <ul>
@@ -183,18 +186,18 @@
         </ul></li>
       <li>Подготовил 4 чемпионов России (WorldSkills 2018‑2021)</li>
     </ul>
-    <h4>Личные награды</h4>
+    <h3>Личные награды</h3>
     <ul>
       <li>🥈 Серебро — Межрегиональный чемпионат «Реверсивный инжиниринг», Оренбург 2025</li>
       <li>🥉 Бронза — Финал Чемпионата высоких технологий, Великий Новгород 2023</li>
     </ul>
-    <h4>Команда «Дезинтегратор»</h4>
+    <h3>Команда «Дезинтегратор»</h3>
     <ul><li>TOP 16 «Битвы роботов» (100 + кг) — 2023‑2024</li></ul>
-  </details>
+  </section>
 
   <!-- ===== Экспертная деятельность ===== -->
-  <details id="expert">
-    <summary><strong>Экспертная деятельность</strong></summary>
+  <section id="expert">
+    <h2>Экспертная деятельность</h2>
     <div class="carousel" id="expertCarousel">
       <button class="prev" id="expertPrev" aria-label="Предыдущее фото">&#10094;</button>
       <img loading="lazy" id="expertImg" src="" alt="Экспертное фото" />
@@ -209,12 +212,12 @@
       <li>«Реверсивный инжиниринг» — финал России, Санкт‑Петербург 2023</li>
       <li>«Изготовление индивидуальных имплантов» — Москва 2024</li>
     </ul>
-  </details>
+  </section>
 
 
 <!-- ===== Публикации ===== -->
-<details id="publications">
-  <summary><strong>Публикации и интервью</strong></summary>
+<section id="publications">
+  <h2>Публикации и интервью</h2>
   <div class="lectures-grid">
     <figure>
       <img loading="lazy" src="https://via.placeholder.com/200x120.png?text=Лекция+1" alt="Миниатюра лекции 1" />
@@ -241,18 +244,19 @@
       <figcaption>Название лекции 6</figcaption>
     </figure>
   </div>
-</details>
+</section>
 
-<details id="portfolio">
-  <summary><strong>Портфолио</strong></summary>
+<section id="portfolio">
+  <h2>Портфолио</h2>
   <p>Раздел в разработке.</p>
-</details>
+</section>
 
-<details id="interests">
-  <summary><strong>Интересы</strong></summary>
-  <p>3D-печать, робототехника, аддитивные технологии и путешествия.</p>
-</details>
+  <section id="interests">
+    <h2>Интересы</h2>
+    <p>3D-печать, робототехника, аддитивные технологии и путешествия.</p>
+  </section>
 
+  </main>
   <script src="script.js"></script>
 </body>
 </html>

--- a/index_en.html
+++ b/index_en.html
@@ -10,7 +10,7 @@
   <meta property="og:description" content="Moscow, 34 years old, expert in industrial design and engineering" />
   <meta property="og:type" content="profile" />
   <meta property="og:locale" content="ru_RU" />
-  <meta name="description" content="Краткое описание визитки" />
+  <meta name="description" content="Short business card of Vladimir Ganshin with contacts and experience" />
 
   <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@300;400;600&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="style.css" />
@@ -19,7 +19,7 @@
 <body itemscope itemtype="https://schema.org/Person">
 <header>
   <h1 itemprop="name">Vladimir Ganshin</h1>
-  <img loading="lazy" id="avatar" src="Avatar_Ganshin.jpg" alt="Avatar of Vladimir Ganshin" itemprop="image" style="max-width:200px;border-radius:0;cursor:pointer;" />
+  <img loading="lazy" id="avatar" src="Avatar_Ganshin.jpg" alt="Avatar of Vladimir Ganshin" itemprop="image" />
   <p class="tagline" itemprop="description">Moscow, 34 years old, expert in industrial design and engineering</p>
 
   <!-- 5. presentгация-якоря -->
@@ -37,13 +37,14 @@
     <a href="#interests">Interests</a>
   </nav>
 </header>
+<main>
   <div id="storyOverlay">
     <img loading="lazy" id="storyImg" src="" alt="Story photo of Vladimir Ganshin" />
   </div>
 
   <!-- ===== Contacts ===== -->
-  <details id="contacts" open itemprop="address" itemscope itemtype="https://schema.org/PostalAddress">
-    <summary><strong>Contacts</strong></summary>
+  <section id="contacts" itemprop="address" itemscope itemtype="https://schema.org/PostalAddress">
+    <h2>Contacts</h2>
       <address>
     <ul>
       <li itemprop="addressLocality">Moscow, Russia</li>
@@ -60,47 +61,50 @@
         <a href="https://t.me/yourhandle" itemprop="sameAs">t.me/yourhandle</a> |
         <a href="https://linkedin.com/in/ganjshin" itemprop="sameAs">linkedin.com/in/ganjshin</a>
       </li>
-    </ul>
-      </address>
-  </details>
+      </ul>
+    </address>
+  </section>
 
   <!-- ===== About me ===== -->
-  <details id="about">
-    <summary><strong>About me briefly</strong></summary>
+  <section id="about">
+    <h2>About me briefly</h2>
     <video class="about-video" src="output_compressed.mp4" controls></video>
     <p>Since 2019 I lead the technopark of the Russian State Social University (RSSU) and teach engineering disciplines at the Pyatigorsk branch.</p>
-    <h4>Key facts</h4>
+    <h3>Key facts</h3>
     <ul>
       <li><strong>25+</strong> applied engineering projects per year</li>
       <li><strong>300+</strong> trained students and professionals</li>
       <li><strong>10</strong> medals at national and international championships</li>
       <li><strong>1 200+</strong> academic hours of proprietary courses</li>
     </ul>
-  </details>
+  </section>
 
   <!-- ===== Positions ===== -->
-  <details id="positions">
-    <summary><strong>Current positions</strong></summary>
+  <section id="positions">
+    <h2>Current positions</h2>
     <table>
+      <caption>Teaching experience</caption>
+      <caption>Education</caption>
+      <caption>Current positions</caption>
       <thead><tr><th>Years</th><th>Position</th><th>Organization</th></tr></thead>
       <tbody>
         <tr><td>2019 – present</td><td itemprop="jobTitle">Head of technopark</td><td>RSSU, Moscow</td></tr>
         <tr><td>2019 – present</td><td itemprop="jobTitle">Lecturer</td><td>RSSU, Pyatigorsk branch</td></tr>
       </tbody>
     </table>
-  </details>
+  </section>
 
   <!-- ===== Skills ===== -->
-  <details id="skills">
-    <summary><strong>Skills and tools</strong></summary>
-    <h4>Key skills</h4>
+  <section id="skills">
+    <h2>Skills and tools</h2>
+    <h3>Key skills</h3>
     <ul>
       <li>CAD/CAM/CAE‑моделирование</li>
       <li>Реверсивный инжиниринг</li>
       <li>Аддитивное производство (FDM, DLP, SLA)</li>
       <li>Промышленный дизайн и прототипирование</li>
     </ul>
-    <h4>Technology stack</h4>
+    <h3>Technology stack</h3>
     <p><strong>CAD:</strong></p>
     <ul class="tech-list">
       <li><img loading="lazy" class="icon" src="https://raw.githubusercontent.com/simple-icons/simple-icons/master/icons/autodesk.svg" alt="Logo of Inventor Professional" /> Inventor Professional</li>
@@ -126,11 +130,11 @@
       <li><img loading="lazy" class="icon" src="https://raw.githubusercontent.com/simple-icons/simple-icons/master/icons/cplusplus.svg" alt="Logo of C++" /> C++</li>
       <li><img loading="lazy" class="icon" src="https://raw.githubusercontent.com/simple-icons/simple-icons/master/icons/python.svg" alt="Logo of Python" /> Python</li>
     </ul>
-  </details>
+  </section>
 
   <!-- ===== Education ===== -->
-  <details id="education">
-    <summary><strong>Education</strong></summary>
+  <section id="education">
+    <h2>Education</h2>
     <table>
       <thead><tr><th>Years</th><th>Institution</th><th>Qualification</th></tr></thead>
       <tbody>
@@ -139,16 +143,16 @@
         <tr><td>2014‑2018</td><td>MSTU "Stankin"</td><td>Postgraduate studies, specialty 05.02.07 "Technology and equipment for mechanical and physical-technical processing"</td></tr>
       </tbody>
     </table>
-    <h4>Professional development</h4>
+    <h3>Professional development</h3>
     <ul>
       <li>Engineering design CAD — Moscow Polytechnic</li>
       <li>State and municipal management — RSSU</li>
     </ul>
-  </details>
+  </section>
 
   <!-- ===== Teaching experience ===== -->
-  <details id="experience">
-    <summary><strong>Педагогический опыт</strong></summary>
+  <section id="experience">
+    <h2>Teaching experience</h2>
     <table>
       <thead><tr><th>Период</th><th>Организация</th><th>Роль</th></tr></thead>
       <tbody>
@@ -157,7 +161,7 @@
         <tr><td>2021-2022</td><td>School "Maryina Roshcha named after V.F. Orlov"</td><td>Distance learning teacher (IT classes)</td></tr>
       </tbody>
     </table>
-    <h4>Courses taught</h4>
+    <h3>Courses taught</h3>
     <ul>
       <li><strong>Industrial design and engineering</strong> (автор)</li>
       <li><strong>Engineering design (CAD)</strong> (автор)</li>
@@ -165,12 +169,12 @@
       <li><strong>AI technologies in professional activities</strong> (автор)</li>
       <li><strong>Concept of modern science</strong> (соавтор)</li>
     </ul>
-  </details>
+  </section>
 
   <!-- ===== Awards and achievements ===== -->
-  <details id="awards">
-    <summary><strong>Achievements and awards</strong></summary>
-    <h4>Coaching achievements</h4>
+  <section id="awards">
+    <h2>Achievements and awards</h2>
+    <h3>Coaching achievements</h3>
     <ul>
       <li>Coach of the Russian national team (2019-2021)
         <ul>
@@ -179,18 +183,18 @@
         </ul></li>
       <li>Trained 4 champions of Russia (WorldSkills 2018-2021)</li>
     </ul>
-    <h4>Personal awards</h4>
+    <h3>Personal awards</h3>
     <ul>
       <li>🥈 Silver — Interregional "Reverse Engineering" Championship, Orenburg 2025</li>
       <li>🥉 Bronze — High Technology Championship finals, Veliky Novgorod 2023</li>
     </ul>
-    <h4>Team "Disintegrator"</h4>
+    <h3>Team "Disintegrator"</h3>
     <ul><li>TOP 16 "Robot Battles" (100+ kg) — 2023-2024</li></ul>
-  </details>
+  </section>
 
   <!-- ===== Expert activity ===== -->
-  <details id="expert">
-    <summary><strong>Expertная деятельность</strong></summary>
+  <section id="expert">
+    <h2>Expert activity</h2>
     <div class="carousel" id="expertCarousel">
       <button class="prev" id="expertPrev" aria-label="Previous photo">&#10094;</button>
       <img loading="lazy" id="expertImg" src="" alt="Expert photo" />
@@ -205,12 +209,12 @@
       <li>"Reverse Engineering" — Russia finals, St. Petersburg 2023</li>
       <li>"Individual implant manufacturing" — Moscow 2024</li>
     </ul>
-  </details>
+  </section>
 
 
 <!-- ===== Publications ===== -->
-<details id="publications">
-  <summary><strong>Publications and interviews</strong></summary>
+<section id="publications">
+  <h2>Publications and interviews</h2>
   <div class="lectures-grid">
     <figure>
       <img loading="lazy" src="https://via.placeholder.com/200x120.png?text=Lecture+1" alt="Lecture 1 thumbnail" />
@@ -237,18 +241,19 @@
       <figcaption>Lecture title 6</figcaption>
     </figure>
   </div>
-</details>
+</section>
 
-<details id="portfolio">
-  <summary><strong>Portfolio</strong></summary>
+<section id="portfolio">
+  <h2>Portfolio</h2>
   <p>Section under development.</p>
-</details>
+</section>
 
-<details id="interests">
-  <summary><strong>Interests</strong></summary>
-  <p>3D printing, robotics, additive technologies and travel.</p>
-</details>
+  <section id="interests">
+    <h2>Interests</h2>
+    <p>3D printing, robotics, additive technologies and travel.</p>
+  </section>
 
+  </main>
   <script src="script.js"></script>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -51,6 +51,10 @@ h1 {
   font-size: 0.9rem;
 }
 
+section {
+  margin-bottom: 1.5rem;
+}
+
 .top-nav a {
   text-decoration: none;
   color: inherit;
@@ -195,6 +199,9 @@ thead th {
   border: 3px solid #f08080;
   padding: 2px;
   box-sizing: border-box;
+  max-width: 200px;
+  border-radius: 0;
+  cursor: pointer;
 }
 
 #storyOverlay {


### PR DESCRIPTION
## Summary
- refactor index pages to use `<main>` and `<section>` elements
- convert headings to proper level tags
- move avatar inline styles to CSS and add spacing for sections
- update meta descriptions

## Testing
- `tidy -q index.html` *(fails: command not found)*
- `htmlhint index.html` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847bfff72ac833383879b1f3b8fe364